### PR TITLE
Add ability to expose the used mechanism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ ylwrap
 src/lex.c
 src/parser.c
 src/parser.h
+testdir/
 *.o
 *.lo
 *.la

--- a/README
+++ b/README
@@ -109,6 +109,7 @@ Configuration Directives
 [GssapiNameAttributes](#gssapinameattributes)<br>
 [GssapiNegotiateOnce](#gssapinegotiateonce)<br>
 [GssapiPublishErrors](#gssapipublisherrors)<br>
+[GssapiPublishMech](#gssapipublishmech)<br>
 [GssapiRequiredNameAttributes](#gssapirequirednameattributes)<br>
 [GssapiSessionKey](#gssapisessionkey)<br>
 [GssapiSignalPersistentAuth](#gssapisignalpersistentauth)<br>
@@ -543,3 +544,17 @@ Note: the value is specified in seconds.
 Sets ticket/session validity to 10 hours.
 
 
+### GssapiPublishMech
+
+This option is used to publish the mech used for authentication as an
+Environment variable named GSS_MECH.
+
+It will return a string of the form 'Authtype/Mechname'.
+Authtype represents the type of auth performed by the module. Possible values
+are 'Basic', 'Negotiate', 'NTLM', 'Impersonate'.
+Mechname is the name of the mechanism as reported by GSSAPI or the OID of the
+mechanism if a name is not available. In case of errors the 'Unavailable'
+string may also be returned for either Authtype or Mechname.
+
+- **Enable with:** GssapiPublishMech On
+- **Default:** GssapiPublishMech Off

--- a/src/environ.h
+++ b/src/environ.h
@@ -18,3 +18,5 @@ void mag_publish_error(request_rec *req, uint32_t maj, uint32_t min,
                        const char *gss_err, const char *mag_err);
 void mag_set_req_attr_fail(request_rec *req, struct mag_config *cfg,
                            struct mag_conn *mc);
+void mag_publish_mech(request_rec *req, struct mag_conn *mc,
+                      const char *auth_type, gss_OID mech_type);

--- a/src/mod_auth_gssapi.c
+++ b/src/mod_auth_gssapi.c
@@ -1294,6 +1294,10 @@ static int mag_complete(struct mag_req_cfg *req_cfg, struct mag_conn *mc,
         mc->user_name = apr_pstrdup(mc->pool, mc->gss_name);
     }
 
+    if (cfg->pubmech) {
+        mag_publish_mech(req, mc, mag_str_auth_type(mc->auth_type), mech_type);
+    }
+
     mc->established = true;
     if (req_cfg->use_sessions) {
         mag_attempt_session(req_cfg, mc);
@@ -1899,6 +1903,9 @@ static const command_rec mag_commands[] = {
     AP_INIT_FLAG("GssapiPublishErrors", ap_set_flag_slot,
                  (void *)APR_OFFSETOF(struct mag_config, enverrs), OR_AUTHCFG,
                  "Publish GSSAPI Errors in Envionment Variables"),
+    AP_INIT_FLAG("GssapiPublishMech", ap_set_flag_slot,
+                 (void *)APR_OFFSETOF(struct mag_config, pubmech), OR_AUTHCFG,
+                 "Publish GSSAPI Mech Name in Envionment Variables"),
     AP_INIT_RAW_ARGS("GssapiAcceptorName", mag_acceptor_name, NULL, OR_AUTHCFG,
                      "Name of the acceptor credentials."),
     AP_INIT_TAKE1("GssapiBasicTicketTimeout", mag_basic_timeout, NULL,

--- a/src/mod_auth_gssapi.h
+++ b/src/mod_auth_gssapi.h
@@ -95,6 +95,7 @@ struct mag_config {
     struct mag_name_attributes *name_attributes;
     const char *required_na_expr;
     int enverrs;
+    int pubmech;
     gss_name_t acceptor_name;
     bool acceptor_name_from_req;
     uint32_t basic_timeout;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -6,14 +6,16 @@ EXTRA_DIST = \
 	index.html \
 	localname.html \
 	magtests.py \
+	mech.html \
 	t_bad_acceptor_name.py \
 	t_basic_k5_fail_second.py \
 	t_basic_k5.py \
 	t_basic_k5_two_users.py \
 	t_basic_proxy.py \
 	t_basic_timeout.py \
-	t_localname.py \
 	t_hostname_acceptor.py \
+	t_localname.py \
+	t_mech_name.py \
 	t_nonego.py \
 	t_required_name_attr.py \
 	t_spnego_negotiate_once.py \

--- a/tests/httpd.conf
+++ b/tests/httpd.conf
@@ -331,3 +331,18 @@ CoreDumpDirectory "{HTTPROOT}"
   GssapiSessionKey file:{HTTPROOT}/session.key
   Require valid-user
 </Location>
+
+<Location /mech_name>
+  Options +Includes
+  AddOutputFilter INCLUDES .html
+  AuthType GSSAPI
+  AuthName "Password Login"
+  GssapiSSLonly Off
+  GssapiCredStore ccache:{HTTPROOT}/tmp/httpd_krb5_ccache
+  GssapiCredStore client_keytab:{HTTPROOT}/http.keytab
+  GssapiCredStore keytab:{HTTPROOT}/http.keytab
+  GssapiBasicAuth On
+  GssapiBasicAuthMech krb5
+  GssapiPublishMech On
+  Require valid-user
+</Location>

--- a/tests/magtests.py
+++ b/tests/magtests.py
@@ -773,6 +773,22 @@ def http_restart(testdir, so_dir, testenv):
     return httpproc
 
 
+def test_mech_name(testdir, testenv, logfile):
+    basicdir = os.path.join(testdir, 'httpd', 'html', 'mech_name')
+    os.mkdir(basicdir)
+    shutil.copy('tests/mech.html', basicdir)
+
+    mname = subprocess.Popen(["tests/t_mech_name.py"],
+                             stdout=logfile, stderr=logfile,
+                             env=testenv, preexec_fn=os.setsid)
+    mname.wait()
+    if mname.returncode != 0:
+        sys.stderr.write('MECH-NAME: FAILED\n')
+        return 1
+    sys.stderr.write('MECH-NAME: SUCCESS\n')
+    return 0
+
+
 if __name__ == '__main__':
     args = parse_args()
 
@@ -831,6 +847,8 @@ if __name__ == '__main__':
         errs += test_basic_auth_krb5(testdir, testenv, logfile)
 
         errs += test_no_negotiate(testdir, testenv, logfile)
+
+        errs += test_mech_name(testdir, testenv, logfile)
 
         # After this point we need to speed up httpd to test creds timeout
         try:

--- a/tests/mech.html
+++ b/tests/mech.html
@@ -1,0 +1,1 @@
+<!--#echo var="GSS_MECH" -->

--- a/tests/t_mech_name.py
+++ b/tests/t_mech_name.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+# Copyright (C) 2015 - mod_auth_gssapi contributors, see COPYING for license.
+
+import os
+import requests
+from requests.auth import HTTPBasicAuth
+
+
+if __name__ == '__main__':
+    url = 'http://%s/mech_name/mech.html' % os.environ['NSS_WRAPPER_HOSTNAME']
+    r = requests.get(url, auth=HTTPBasicAuth(os.environ['MAG_USER_NAME'],
+                                             os.environ['MAG_USER_PASSWORD']))
+    if r.status_code != 200:
+        raise ValueError('Basic Auth Failed')
+
+    if r.text.rstrip() != 'Basic/krb5':
+        raise ValueError(
+            'GSS_MECH check failed, expected Basic/krb5, got "%s"' %
+            r.text.rstrip())


### PR DESCRIPTION
A new option named GssapiPublishMech enables setting an environemnt
variable named GSS_MECH that exposes the authentication type and
mechanism used for authentication.

Fixes #199 