### PR TITLE
Emit error in logs if keytab files can't be opened

### DIFF
--- a/src/mod_auth_gssapi.c
+++ b/src/mod_auth_gssapi.c
@@ -1532,6 +1532,23 @@ static const char *mag_cred_store(cmd_parms *parms, void *mconfig,
     }
     cfg->cred_store->count++;
 
+    /* check for files that we know should be present, so admins get
+     * some rope to figure out issues when they cannot be accessed */
+    if (strcmp(key, "keytab") == 0 ||
+        strcmp(key, "client_keytab") == 0) {
+        apr_status_t rc;
+        apr_file_t *file;
+        rc = apr_file_open(&file, value, APR_FOPEN_READ, 0, parms->pool);
+        if (rc != APR_SUCCESS) {
+            char err[256];
+            apr_strerror(rc, err, sizeof(err));
+            ap_log_error(APLOG_MARK, APLOG_ERR, 0, parms->server,
+                         "Cannot open %s file %s: %s", key, value, err);
+        } else {
+            apr_file_close(file);
+        }
+    }
+
     elements[count].key = key;
     elements[count].value = value;
 

--- a/tests/httpd.conf
+++ b/tests/httpd.conf
@@ -346,3 +346,16 @@ CoreDumpDirectory "{HTTPROOT}"
   GssapiPublishMech On
   Require valid-user
 </Location>
+
+<Location /keytab_file_check>
+  AuthType GSSAPI
+  AuthName "Password Login"
+  GssapiSSLonly Off
+  GssapiCredStore ccache:{HTTPROOT}/tmp/httpd_krb5_ccache
+  GssapiCredStore client_keytab:{HTTPROOT}/nofile/http.keytab
+  GssapiCredStore keytab:{HTTPROOT}/nofile/http.keytab
+  GssapiBasicAuth On
+  GssapiBasicAuthMech krb5
+  GssapiPublishMech On
+  Require valid-user
+</Location>

--- a/tests/t_file_check.py
+++ b/tests/t_file_check.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+# Copyright (C) 2020 - mod_auth_gssapi contributors, see COPYING for license.
+
+import os
+
+import requests
+from requests.auth import HTTPBasicAuth
+
+
+if __name__ == '__main__':
+    url = 'http://%s/keytab_file_check/' % os.environ['NSS_WRAPPER_HOSTNAME']
+    r = requests.get(url, auth=HTTPBasicAuth(os.environ['MAG_USER_NAME'],
+                                             os.environ['MAG_USER_PASSWORD']))
+    if r.status_code != 200:
+        raise ValueError('Basic Auth Failed(Keytab File Check)')


### PR DESCRIPTION
This will give a useful warning to admins when config point to missing
files.

Fixes #228 