### PR TITLE
Move to python3 by default

### DIFF
--- a/README
+++ b/README
@@ -26,8 +26,8 @@ To run tests, you also need:
 
 * The Kerberos 5 Key-Distribution-Center (`krb5-kdc` package on Debian,
   `krb5-server` on Fedora)
-* Packages `mod_session`, `krb5-workstation`, `python-requests-gssapi`,
-  and `python-gssapi` on Fedora
+* Packages `mod_session`, `krb5-workstation`, `python3-requests-gssapi`,
+  and `python3-gssapi` on Fedora
 * Some tests require `krb5-pkinit` package on fedora and krb5 >= 1.15.
 * [nss_wrapper](https://cwrap.org/nss_wrapper.html), packaged in Fedora
 * [socket_wrapper](https://cwrap.org/socket_wrapper.html), packaged in Fedora

--- a/contrib/session_generator.py
+++ b/contrib/session_generator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Works with both python2 and python3; please preserve this property
 
 # Copyright (C) 2016 mod_auth_gssapi contributors - See COPYING for (C) terms

--- a/contrib/sweeper.py
+++ b/contrib/sweeper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Works with both python2 and python3; please preserve this property
 
 # Copyright (C) 2016 mod_auth_gssapi contributors - See COPYING for (C) terms

--- a/tests/magtests.py
+++ b/tests/magtests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (C) 2015 - mod_auth_gssapi contributors, see COPYING for license.
 
 import argparse

--- a/tests/magtests.py
+++ b/tests/magtests.py
@@ -322,7 +322,7 @@ def setup_kdc(testdir, wrapenv):
 
     kdcenv = wrapenv.copy()
     kdcenv.update({
-        'PATH': f'/sbin:/bin:/usr/sbin:/usr/bin:{wrapenv["PATH"]}',
+        'PATH': f'{wrapenv["PATH"]}:/sbin:/bin:/usr/sbin:/usr/bin',
         'KRB5_CONFIG': krb5conf,
         'KRB5_KDC_PROFILE': kdcconf,
         'KRB5_TRACE': os.path.join(testdir, 'krbtrace.log'),

--- a/tests/t_bad_acceptor_name.py
+++ b/tests/t_bad_acceptor_name.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (C) 2015 - mod_auth_gssapi contributors, see COPYING for license.
 
 import os

--- a/tests/t_basic_k5.py
+++ b/tests/t_basic_k5.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (C) 2015 - mod_auth_gssapi contributors, see COPYING for license.
 
 import os

--- a/tests/t_basic_k5_fail_second.py
+++ b/tests/t_basic_k5_fail_second.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (C) 2015 - mod_auth_gssapi contributors, see COPYING for license.
 
 import os

--- a/tests/t_basic_k5_two_users.py
+++ b/tests/t_basic_k5_two_users.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (C) 2015 - mod_auth_gssapi contributors, see COPYING for license.
 
 import os

--- a/tests/t_basic_proxy.py
+++ b/tests/t_basic_proxy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (C) 2015 - mod_auth_gssapi contributors, see COPYING for license.
 
 import os

--- a/tests/t_basic_timeout.py
+++ b/tests/t_basic_timeout.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (C) 2020 - mod_auth_gssapi contributors, see COPYING for license.
 
 import os

--- a/tests/t_file_check.py
+++ b/tests/t_file_check.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (C) 2020 - mod_auth_gssapi contributors, see COPYING for license.
 
 import os

--- a/tests/t_hostname_acceptor.py
+++ b/tests/t_hostname_acceptor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (C) 2017 - mod_auth_gssapi contributors, see COPYING for license.
 
 import sys

--- a/tests/t_localname.py
+++ b/tests/t_localname.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (C) 2020 - mod_auth_gssapi contributors, see COPYING for license.
 
 import os

--- a/tests/t_mech_name.py
+++ b/tests/t_mech_name.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (C) 2015 - mod_auth_gssapi contributors, see COPYING for license.
 
 import os

--- a/tests/t_nonego.py
+++ b/tests/t_nonego.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (C) 2015 - mod_auth_gssapi contributors, see COPYING for license.
 
 import os

--- a/tests/t_required_name_attr.py
+++ b/tests/t_required_name_attr.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (C) 2015 - mod_auth_gssapi contributors, see COPYING for license.
 
 import os

--- a/tests/t_spnego.py
+++ b/tests/t_spnego.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (C) 2015 - mod_auth_gssapi contributors, see COPYING for license.
 
 import os

--- a/tests/t_spnego_negotiate_once.py
+++ b/tests/t_spnego_negotiate_once.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (C) 2015 - mod_auth_gssapi contributors, see COPYING for license.
 
 import os

--- a/tests/t_spnego_no_auth.py
+++ b/tests/t_spnego_no_auth.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (C) 2015 - mod_auth_gssapi contributors, see COPYING for license.
 
 import os

--- a/tests/t_spnego_proxy.py
+++ b/tests/t_spnego_proxy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (C) 2015 - mod_auth_gssapi contributors, see COPYING for license.
 
 import os

--- a/tests/t_spnego_rewrite.py
+++ b/tests/t_spnego_rewrite.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (C) 2015 - mod_auth_gssapi contributors, see COPYING for license.
 
 import os


### PR DESCRIPTION
When moving 2 -> 3, python elected to keep "python" as the name of the
python2 interpreter.  As a result, python3-only machines have no
/usr/bin/python.  Since python2 is EOL, it should be safe to make our
scripting default to python3.

Signed-off-by: Robbie Harwood <rharwood@redhat.com>