### PR TITLE
Special ccache handling for {HOSTNAME} acceptor

### DIFF
--- a/tests/httpd.conf
+++ b/tests/httpd.conf
@@ -238,6 +238,21 @@ CoreDumpDirectory "{HTTPROOT}"
   Require valid-user
 </Location>
 
+<Location /hostname_proxy>
+  AuthType GSSAPI
+  AuthName "Login"
+  GssapiSSLonly Off
+  GssapiCredStore ccache:{HTTPROOT}/httpd_krb5_ccache
+  GssapiCredStore client_keytab:{HTTPROOT}/http.keytab
+  GssapiCredStore keytab:{HTTPROOT}/http.keytab
+  GssapiBasicAuth Off
+  GssapiAllowedMech krb5
+  GssapiAcceptorName {{HOSTNAME}}
+  GssapiUseS4U2Proxy On
+  GssapiDelegCcacheDir {HTTPROOT}/delegccachedir
+  Require valid-user
+</Location>
+
 <Location /required_name_attr1>
   AuthType GSSAPI
   AuthName "Required Name Attributes"

--- a/tests/t_hostname_acceptor.py
+++ b/tests/t_hostname_acceptor.py
@@ -9,7 +9,7 @@ from requests_gssapi import HTTPKerberosAuth, OPTIONAL # noqa
 
 if __name__ == '__main__':
     sess = requests.Session()
-    url = 'http://%s/hostname_acceptor/' % sys.argv[1]
+    url = 'http://{}/{}/'.format(sys.argv[1], sys.argv[2])
     r = sess.get(url, auth=HTTPKerberosAuth(delegate=True))
     if r.status_code != 200:
-        raise ValueError('Hostname-based acceptor failed')
+        raise ValueError('Hostname acceptor ({}) failed'.format(sys.argv[2]))


### PR DESCRIPTION
Quoting part of a commit message in this PR: 
    When using the {HOTNAME} acceptor the principal used in the server
    ccache can vary with each request. GSSAPI does not handle gracefully
    a request to resolve a ccache if there is already another credential
    under a different name.

Fixes #234 