### PR TITLE
Add random string option to GssapiDelegCcacheUnique

### DIFF
--- a/README
+++ b/README
@@ -267,10 +267,13 @@ file.
 
 # GssapiDelegCcacheRandom
 
-Adds a 16-character random string to the filename of the delegated ccache.
-This option requires GssapiDelegCcacheUnique to be enabled, and could be used
-to help protect saved tickets if the directory permissions are set
-appropriately.
+Inserts a 96-bit-entropy random string to the filename of the delegated
+ccache. This option requires GssapiDelegCcacheUnique to be enabled, and
+could be used to help protect saved tickets if the directory permissions
+are set appropriately such that users only have traversal (x) but not
+read (r) permissions to discover these filenames, so a user requires
+prior knowledge of fhe filename to access the credential cache (in effect,
+the filename also acts as an access password).
 
 - **Enable with:** GssapiDelegCcacheRandom On
 - **Default:** GssapiDelegCcacheRandom Off

--- a/README
+++ b/README
@@ -103,7 +103,6 @@ Configuration Directives
 [GssapiDelegCcacheDir](#gssapidelegccachedir)<br>
 [GssapiDelegCcacheEnvVar](#gssapidelegccacheenvvar)<br>
 [GssapiDelegCcachePerms](#gssapidelegccacheperms)<br>
-[GssapiDelegCcacheRandom](#gssapidelegccacherandom)<br>
 [GssapiDelegCcacheUnique](#gssapidelegccacheunique)<br>
 [GssapiImpersonate](#gssapiimpersonate)<br>
 [GssapiLocalName](#gssapilocalname)<br>

--- a/README
+++ b/README
@@ -103,6 +103,7 @@ Configuration Directives
 [GssapiDelegCcacheDir](#gssapidelegccachedir)<br>
 [GssapiDelegCcacheEnvVar](#gssapidelegccacheenvvar)<br>
 [GssapiDelegCcachePerms](#gssapidelegccacheperms)<br>
+[GssapiDelegCcacheRandom](#gssapidelegccacherandom)<br>
 [GssapiDelegCcacheUnique](#gssapidelegccacheunique)<br>
 [GssapiImpersonate](#gssapiimpersonate)<br>
 [GssapiLocalName](#gssapilocalname)<br>
@@ -262,6 +263,17 @@ file.
 
 - **Enable with:** GssapiDelegCcacheUnique On
 - **Default:** GssapiDelegCcacheUnique Off
+
+
+# GssapiDelegCcacheRandom
+
+Adds a 16-character random string to the filename of the delegated ccache.
+This option requires GssapiDelegCcacheUnique to be enabled, and could be used
+to help protect saved tickets if the directory permissions are set
+appropriately.
+
+- **Enable with:** GssapiDelegCcacheRandom On
+- **Default:** GssapiDelegCcacheRandom Off
 
 
 ### GssapiDelegCcacheEnvVar

--- a/README
+++ b/README
@@ -256,27 +256,20 @@ Enables using unique ccache names for delegation.  ccache files will be placed
 in GssapiDelegCcacheDir and named using the principal and a six-digit unique
 suffix.
 
+If set to "secure", this option will insert a 96-bit-entropy random string to
+the filename of the delegated ccache. This could be used to help protect saved
+tickets if the directory permissions are set appropriately such that users
+only have traversal (x) but not read (r) permissions to discover these
+filenames, so a user requires prior knowledge of fhe filename to access the
+credential cache (in effect, the filename also acts as an access password).
+
 **Note:** Consuming application must delete the ccache otherwise it will
 litter the filesystem if sessions are used.  An example sweeper can be found
 in the contrib directory.  If using with gssproxy, see note at the top of that
 file.
 
-- **Enable with:** GssapiDelegCcacheUnique On
+- **Options:** GssapiDelegCcacheUnique Off|On|Secure
 - **Default:** GssapiDelegCcacheUnique Off
-
-
-# GssapiDelegCcacheRandom
-
-Inserts a 96-bit-entropy random string to the filename of the delegated
-ccache. This option requires GssapiDelegCcacheUnique to be enabled, and
-could be used to help protect saved tickets if the directory permissions
-are set appropriately such that users only have traversal (x) but not
-read (r) permissions to discover these filenames, so a user requires
-prior knowledge of fhe filename to access the credential cache (in effect,
-the filename also acts as an access password).
-
-- **Enable with:** GssapiDelegCcacheRandom On
-- **Default:** GssapiDelegCcacheRandom Off
 
 
 ### GssapiDelegCcacheEnvVar

--- a/src/mod_auth_gssapi.c
+++ b/src/mod_auth_gssapi.c
@@ -1495,18 +1495,25 @@ static const char *mag_use_s4u2p(cmd_parms *parms, void *mconfig, int on)
 }
 
 static const char *mag_deleg_ccache_unique(cmd_parms *parms, void *mconfig,
-                                           int on)
+                                           const char *arg)
 {
     struct mag_config *cfg = (struct mag_config *)mconfig;
-    cfg->deleg_ccache_unique = on ? true : false;
-    return NULL;
-}
 
-static const char *mag_deleg_ccache_random(cmd_parms *parms, void *mconfig,
-                                           int on)
-{
-    struct mag_config *cfg = (struct mag_config *)mconfig;
-    cfg->deleg_ccache_random = on ? true : false;
+    if (ap_cstr_casecmp(arg, "on") == 0) {
+        cfg->deleg_ccache_unique = true;
+        cfg->deleg_ccache_random = false;
+    }
+    else if (ap_cstr_casecmp(arg, "off") == 0) {
+        cfg->deleg_ccache_unique = false;
+        cfg->deleg_ccache_random = false;
+    }
+    else if (ap_cstr_casecmp(arg, "secure") == 0) {
+        cfg->deleg_ccache_unique = true;
+        cfg->deleg_ccache_random = true;
+    }
+    else {
+        return "GssapiDelegCcacheUnique must be set to on, off or secure";
+    }
     return NULL;
 }
 
@@ -2028,10 +2035,8 @@ static const command_rec mag_commands[] = {
     AP_INIT_TAKE1("GssapiDelegCcacheEnvVar", ap_set_string_slot,
                     (void *)APR_OFFSETOF(struct mag_config, ccname_envvar),
                     OR_AUTHCFG, "Environment variable to receive ccache name"),
-    AP_INIT_FLAG("GssapiDelegCcacheUnique", mag_deleg_ccache_unique, NULL,
+    AP_INIT_TAKE1("GssapiDelegCcacheUnique", mag_deleg_ccache_unique, NULL,
                  OR_AUTHCFG, "Use unique ccaches for delgation"),
-    AP_INIT_FLAG("GssapiDelegCcacheRandom", mag_deleg_ccache_random, NULL,
-                 OR_AUTHCFG, "Add a random string to the ccache name"),
     AP_INIT_FLAG("GssapiImpersonate", ap_set_flag_slot,
           (void *)APR_OFFSETOF(struct mag_config, s4u2self), OR_AUTHCFG,
                "Do impersonation call (S4U2Self) "

--- a/src/mod_auth_gssapi.c
+++ b/src/mod_auth_gssapi.c
@@ -343,11 +343,12 @@ static char *get_random_string(apr_size_t length, apr_pool_t *pool)
     apr_generate_random_bytes(data, length);
 
     /* convert into filename-safe characters */
-    char *output = apr_palloc(pool, length);
+    char *output = apr_palloc(pool, length+1);
     apr_size_t i;
     for (i = 0; i < length; i++) {
         output[i] = chars[data[i] % 64];
     }
+    output[length] = '\0';
 
     return output;
 }

--- a/src/mod_auth_gssapi.h
+++ b/src/mod_auth_gssapi.h
@@ -83,6 +83,7 @@ struct mag_config {
     gid_t deleg_ccache_gid;
     gss_key_value_set_desc *cred_store;
     bool deleg_ccache_unique;
+    bool deleg_ccache_random;
     int s4u2self;
     char *ccname_envvar;
 #endif


### PR DESCRIPTION
This adds an additional option to the GssapiDelegCcacheUnique directive, which introduces an additional random string into the credential cache filename before storing it.

The intended purpose of the patch is to allow for situations where other processes running as the same user shouldn't be able to access the tickets unless specifically given access - in this case, if the credential cache directory is set up with `d-wx` permissions, the filename effectively becomes an access password to find the stored credentials.