### PR TITLE
crypto: Handle EVP changes in OpenSSL 3

### DIFF
--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -16,7 +16,7 @@ elif [ -f /etc/fedora-release ]; then
         krb5-{server,workstation,pkinit} curl libfaketime \
         {httpd,krb5,openssl,gssntlmssp}-devel {socket,nss}_wrapper \
         autoconf automake libtool which bison make python3 python3-devel \
-        flex mod_session redhat-rpm-config /usr/bin/virtualenv
+        flex mod_session redhat-rpm-config /usr/bin/virtualenv openssl
 else
     echo "Distro not found!"
     false

--- a/src/crypto.c
+++ b/src/crypto.c
@@ -262,7 +262,7 @@ apr_status_t UNSEAL_BUFFER(apr_pool_t *p, struct seal_key *skey,
 
     totlen += outlen;
     outlen = plain->length - totlen;
-    ret = EVP_DecryptFinal_ex(ctx, plain->value, &outlen);
+    ret = EVP_DecryptFinal_ex(ctx, plain->value + totlen, &outlen);
     if (ret == 0) goto done;
 
     totlen += outlen;


### PR DESCRIPTION
OpenSSL 3 changes the padding behavior of EVP_DecryptFinal_ex(), which
causes our decryption to fail.  It is the opnion of the OpenSSL
developers that mod_auth_gssapi's use of this function was incorrect.

Patch suggested by Tomáš Mráz.

Related: https://github.com/openssl/openssl/issues/16351

Signed-off-by: Robbie Harwood <rharwood@redhat.com>