### PR TITLE
Package tests/t_file_check.py

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -13,6 +13,7 @@ EXTRA_DIST = \
 	t_basic_k5_two_users.py \
 	t_basic_proxy.py \
 	t_basic_timeout.py \
+	t_file_check.py \
 	t_hostname_acceptor.py \
 	t_localname.py \
 	t_mech_name.py \


### PR DESCRIPTION
The file tests/t_file_check.py is missing from the tar because it's not listed in tests/Makefile.am in the EXTRA_DIST variable.
Add the test file.

Fixes: https://github.com/gssapi/mod_auth_gssapi/issues/309